### PR TITLE
FIX if-then-else example

### DIFF
--- a/docs/public/js/manual-search.js
+++ b/docs/public/js/manual-search.js
@@ -44,7 +44,7 @@ $(function() {
   $.each($('.manual-example table'), function(index, value) {
     $value = $(value)
     var j = $value.find('tr:nth-child(2) td:first').text();
-    var q = $value.find('.jqprogram').text().replace(/^jq /, '').replace(/^'(.+)'$/, '$1');
+    var q = $value.find('.jqprogram').text().replace(/^jq /, '').replace(/(\r\n|\n|\r)/gm," ").replace(/^'(.+)'$/, '$1');
     var url = 'https://jqplay.org/jq?q=' + encodeURIComponent(q) +'&j=' + encodeURIComponent(j)
     var $last_tr = $value.find('tr:last');
     $last_tr.after('<tr class="jqplay-btn"><th><a href="' + url + '" class="btn btn-primary btn-sm">Run</a></th><th></th></tr><tr><th></th><th></th></tr>');


### PR DESCRIPTION
"(.+)" doesn't match new line characters so the link generated for [if-then-else](https://github.com/stedolan/jq/blob/90bc29c1b544c0436ec44246e180fdbb6d6384df/docs/content/3.manual/v1.5/manual.yml#L1804) doesn't work.

It generates; https://jqplay.org/jq?q=%27if%20.%20%3D%3D%200%20then%0A%20%20%22zero%22%0Aelif%20.%20%3D%3D%201%20then%0A%20%20%22one%22%0Aelse%0A%20%20%22many%22%0Aend%27&j=2

But it should be;
https://jqplay.org/jq?q=if%20.%20%3D%3D%200%20then%20%20%20%22zero%22%20elif%20.%20%3D%3D%201%20then%20%20%20%22one%22%20else%20%20%20%22many%22%20end&j=2
